### PR TITLE
Fixed the RD registration list to move on to generic objects when no simple object instances exists

### DIFF
--- a/apps/oma-lwm2m/lwm2m-engine.c
+++ b/apps/oma-lwm2m/lwm2m-engine.c
@@ -897,12 +897,13 @@ static lwm2m_object_instance_t *
 create_instance(lwm2m_context_t *context, lwm2m_object_t *object)
 {
   lwm2m_object_instance_t *instance;
-  if(object == NULL || object->impl == NULL || object->impl->create == NULL) {
+  if(object == NULL || object->impl == NULL ||
+     object->impl->create_instance == NULL) {
     return NULL;
   }
 
   /* NOTE: context->object_instance_id needs to be set before calling */
-  instance = object->impl->create(context->object_instance_id, NULL);
+  instance = object->impl->create_instance(context->object_instance_id, NULL);
   if(instance != NULL) {
     PRINTF("Created instance: %u/%u\n", context->object_id, context->object_instance_id);
     REST.set_response_status(context->response, CREATED_2_01);
@@ -1363,8 +1364,8 @@ lwm2m_handler_callback(coap_packet_t *request, coap_packet_t *response,
       for(object = list_head(generic_object_list);
           object != NULL;
           object = object->next) {
-        if(object->impl != NULL && object->impl->delete != NULL) {
-          object->impl->delete(LWM2M_OBJECT_INSTANCE_NONE, NULL);
+        if(object->impl != NULL && object->impl->delete_instance != NULL) {
+          object->impl->delete_instance(LWM2M_OBJECT_INSTANCE_NONE, NULL);
         }
       }
 #if USE_RD_CLIENT
@@ -1482,8 +1483,9 @@ lwm2m_handler_callback(coap_packet_t *request, coap_packet_t *response,
     success = call_instance(instance, &context);
     break;
   case LWM2M_OP_DELETE:
-    if(object != NULL && object->impl != NULL && object->impl->delete != NULL) {
-      object->impl->delete(context.object_instance_id, &success);
+    if(object != NULL && object->impl != NULL &&
+       object->impl->delete_instance != NULL) {
+      object->impl->delete_instance(context.object_instance_id, &success);
 #if USE_RD_CLIENT
       lwm2m_rd_client_set_update_rd();
 #endif

--- a/apps/oma-lwm2m/lwm2m-engine.h
+++ b/apps/oma-lwm2m/lwm2m-engine.h
@@ -86,9 +86,9 @@ struct lwm2m_object_instance {
 
 typedef struct {
   uint16_t object_id;
-  lwm2m_object_instance_t *(* create)(uint16_t instance_id,
-                                      lwm2m_status_t *status);
-  int (* delete)(uint16_t instance_id, lwm2m_status_t *status);
+  lwm2m_object_instance_t *(* create_instance)(uint16_t instance_id,
+                                               lwm2m_status_t *status);
+  int (* delete_instance)(uint16_t instance_id, lwm2m_status_t *status);
   lwm2m_object_instance_t *(* get_first)(lwm2m_status_t *status);
   lwm2m_object_instance_t *(* get_next)(lwm2m_object_instance_t *instance,
                                         lwm2m_status_t *status);

--- a/apps/oma-lwm2m/lwm2m-security.c
+++ b/apps/oma-lwm2m/lwm2m-security.c
@@ -82,7 +82,7 @@ LIST(instances_list);
 static lwm2m_security_value_t instances[MAX_COUNT];
 /*---------------------------------------------------------------------------*/
 static lwm2m_object_instance_t *
-create(uint16_t instance_id, lwm2m_status_t *status)
+create_instance(uint16_t instance_id, lwm2m_status_t *status)
 {
   lwm2m_object_instance_t *instance;
   int i;
@@ -120,7 +120,7 @@ create(uint16_t instance_id, lwm2m_status_t *status)
 }
 /*---------------------------------------------------------------------------*/
 static int
-delete(uint16_t instance_id, lwm2m_status_t *status)
+delete_instance(uint16_t instance_id, lwm2m_status_t *status)
 {
   lwm2m_object_instance_t *instance;
 
@@ -255,8 +255,8 @@ static const lwm2m_object_impl_t impl = {
   .get_first = get_first,
   .get_next = get_next,
   .get_by_id = get_by_id,
-  .create = create,
-  .delete = delete,
+  .create_instance = create_instance,
+  .delete_instance = delete_instance,
 };
 static lwm2m_object_t reg_object = {
   .impl = &impl,

--- a/apps/oma-lwm2m/lwm2m-server.c
+++ b/apps/oma-lwm2m/lwm2m-server.c
@@ -62,9 +62,9 @@
 static lwm2m_status_t lwm2m_callback(lwm2m_object_instance_t *object,
                                      lwm2m_context_t *ctx);
 
-static lwm2m_object_instance_t *create(uint16_t instance_id,
-                                       lwm2m_status_t *status);
-static int delete(uint16_t instance_id, lwm2m_status_t *status);
+static lwm2m_object_instance_t *create_instance(uint16_t instance_id,
+                                                lwm2m_status_t *status);
+static int delete_instance(uint16_t instance_id, lwm2m_status_t *status);
 static lwm2m_object_instance_t *get_first(lwm2m_status_t *status);
 static lwm2m_object_instance_t *get_next(lwm2m_object_instance_t *instance,
                                          lwm2m_status_t *status);
@@ -82,8 +82,8 @@ static const lwm2m_object_impl_t impl = {
   .get_first = get_first,
   .get_next = get_next,
   .get_by_id = get_by_id,
-  .create = create,
-  .delete = delete,
+  .create_instance = create_instance,
+  .delete_instance = delete_instance,
 };
 static lwm2m_object_t server_object = {
   .impl = &impl,
@@ -93,7 +93,7 @@ LIST(server_list);
 static server_value_t server_instances[MAX_COUNT];
 /*---------------------------------------------------------------------------*/
 static lwm2m_object_instance_t *
-create(uint16_t instance_id, lwm2m_status_t *status)
+create_instance(uint16_t instance_id, lwm2m_status_t *status)
 {
   lwm2m_object_instance_t *instance;
   int i;
@@ -135,7 +135,7 @@ create(uint16_t instance_id, lwm2m_status_t *status)
 }
 /*---------------------------------------------------------------------------*/
 static int
-delete(uint16_t instance_id, lwm2m_status_t *status)
+delete_instance(uint16_t instance_id, lwm2m_status_t *status)
 {
   lwm2m_object_instance_t *instance;
 


### PR DESCRIPTION
Also renamed generic object callbacks `create`/`delete` to `create_instance`/`delete_instance` to avoid compiler issues since `delete` is a keyword in C++.